### PR TITLE
Output to file and better info

### DIFF
--- a/README
+++ b/README
@@ -7,7 +7,7 @@ SYNOPSIS
 DESCRIPTION
 	Automatically fetch your OpenDNS Top Domains data for the given
 	date range in CSV format.  Fetches all pages and combines them
-	into one CSV file, which is printed to STDOUT.
+	into one CSV file, which is printed to "data.csv".
 
 INSTALLATION
 	The script doesn't need to be "installed" but it is nice to put

--- a/fetchstats
+++ b/fetchstats
@@ -5,7 +5,7 @@
 # Brian Hartvigsen <brian.hartvigsen@opendns.com>
 # Richard Crowley <richard@opendns.com>
 #
-
+OUT="data.csv"
 CSVURL="https://dashboard.opendns.com"
 LOGINURL="https://login.opendns.com/?source=dashboard"
 
@@ -49,6 +49,8 @@ USERNAME=`echo -n "$USERNAME" | od -A n -t x1 | tr -d '\n' | sed 's/ *$//;s/[ ]\
 COOKIEJAR=`mktemp /tmp/opendns-fetchstats-XXXXXX`
 
 # Get the signin page's form token
+echo "Logging in"
+
 FORMTOKEN=`curl --silent --insecure \
 	--cookie-jar "$COOKIEJAR" \
 	"$LOGINURL" \
@@ -69,6 +71,9 @@ if [ "$SIGNIN" == "" ]; then
 	echo "Login failed.  Check username and password." >&2
 	exit 2
 fi
+
+echo "Logged in. Fetching..."
+echo "" > "$OUT"
 
 # Fetch pages of Top Domains
 GO="yes"
@@ -92,10 +97,13 @@ while [ "yes" == "$GO" ] ; do
 		CSV=`echo "$CSV" | tail -n +2`
 	fi
 
+    	echo "Loaded page $PAGE"
+    
 	if [ -z "$CSV" ] ; then GO="no"
-	else echo "$CSV" ; fi
+	else echo "$CSV" >> "$OUT"; fi
 	PAGE=$(($PAGE + 1))
 done
 
-rm -f "$COOKIEJAR"
+echo "Done. Output at $OUT"
 
+rm -f "$COOKIEJAR"


### PR DESCRIPTION
This pull request allows for the data output to be put into a file called `data.csv`. In addition, it logs much needed information such as retrieved page numbers.

This change is very useful as it allows for ease of access. Outputting the file's result directly is not very useful for any use and is quite frankly annoying.

In addition, although this PR does not cover this feature, but in the future, flags could be added to control how the data is outputted.

P.S: This does not cover the VB version as I do not know much about that.